### PR TITLE
sort old boxes by version not name

### DIFF
--- a/vagrant_catalog_generator/manage_boxfiles.py
+++ b/vagrant_catalog_generator/manage_boxfiles.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from os import remove, path
 
 from vagrant_catalog_generator.box_list import list_boxes
@@ -25,8 +26,13 @@ def remove_checksum(boxfiles_directory, box):
         logger.info('Could not remove old checksum for {}, probably already gone. Skipping'.format(box))
 
 
+def version_getter(box_name):
+    return re.search('release-([0-9]*).box', box_name).group(1)
+
+
 def only_keep_recent_boxes(boxfiles_directory, boxes, amount=RECENT_BOX_AMOUNT):
-    sorted_boxes = filter(lambda name: 'latest' not in name and not name.endswith('release-1.box'), sorted(boxes))
+    non_critical_boxes = filter(lambda name: 'latest' not in name and not name.endswith('release-1.box'), boxes)
+    sorted_boxes = sorted(non_critical_boxes, key=version_getter)
     old_boxes = list(sorted_boxes)[:-amount]
     for old_box in old_boxes:
         remove_boxfile(boxfiles_directory, old_box)

--- a/vagrant_catalog_generator/tests/unit/manage_boxfiles/test_only_keep_recent_boxes.py
+++ b/vagrant_catalog_generator/tests/unit/manage_boxfiles/test_only_keep_recent_boxes.py
@@ -12,30 +12,40 @@ class TestOnlyKeepRecentBoxes(TestCase):
 
         self.boxes = [
             'hypernode.release-latest.box',
-            'hypernode.vagrant.release-1.box',
-            'hypernode.vagrant.release-2635.box',
-            'hypernode.vagrant.release-2638.box',
-            'hypernode.vagrant.release-2653.box',
-            'hypernode.vagrant.release-2659.box',
-            'hypernode.vagrant.release-2674.box'
+            'hypernode.virtualbox.release-1.box',
+            'hypernode.lxc.release-1.box',
+            'hypernode.virtualbox.release-2635.box',
+            'hypernode.lxc.release-2635.box',
+            'hypernode.virtualbox.release-2638.box',
+            'hypernode.lxc.release-2638.box',
+            'hypernode.virtualbox.release-2653.box',
+            'hypernode.lxc.release-2653.box',
+            'hypernode.virtualbox.release-2659.box',
+            'hypernode.lxc.release-2659.box',
+            'hypernode.virtualbox.release-2674.box',
+            'hypernode.lxc.release-2674.box'
         ]
 
     def test_only_keep_recent_boxes_removes_boxfiles(self):
-        only_keep_recent_boxes('/some/dir', self.boxes, amount=3)
+        only_keep_recent_boxes('/some/dir', self.boxes, amount=6)
 
         expected_calls = [call('/some/dir', box) for box in [
-            'hypernode.vagrant.release-2635.box',
-            'hypernode.vagrant.release-2638.box',
+            'hypernode.virtualbox.release-2635.box',
+            'hypernode.lxc.release-2635.box',
+            'hypernode.virtualbox.release-2638.box',
+            'hypernode.lxc.release-2638.box',
         ]]
 
         self.assertEqual(expected_calls, self.remove_boxfile.mock_calls)
 
     def test_only_keep_recent_boxes_removes_checksum(self):
-        only_keep_recent_boxes('/some/dir', self.boxes, amount=3)
+        only_keep_recent_boxes('/some/dir', self.boxes, amount=6)
 
         expected_calls = [call('/some/dir', box) for box in [
-            'hypernode.vagrant.release-2635.box',
-            'hypernode.vagrant.release-2638.box',
+            'hypernode.virtualbox.release-2635.box',
+            'hypernode.lxc.release-2635.box',
+            'hypernode.virtualbox.release-2638.box',
+            'hypernode.lxc.release-2638.box',
         ]]
 
         self.assertEqual(expected_calls, self.remove_checksum.mock_calls)

--- a/vagrant_catalog_generator/tests/unit/manage_catalog/test_combine_provider_versions.py
+++ b/vagrant_catalog_generator/tests/unit/manage_catalog/test_combine_provider_versions.py
@@ -1,4 +1,3 @@
-import json
 from vagrant_catalog_generator.manage_catalog import combine_provider_versions
 from vagrant_catalog_generator.tests.testcase import TestCase
 


### PR DESCRIPTION
so not only lxc boxes will be deleted when there are more virtualbox
boxes available than the allowed box amount